### PR TITLE
add tomty test for code chunks eval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 # precompiled files
 .precomp
 lib/.precomp
-
+.cache

--- a/.tomty/code-chunks-eval.pl6
+++ b/.tomty/code-chunks-eval.pl6
@@ -1,0 +1,4 @@
+
+task-run ".tomty/tasks/code-chunks-eval";
+
+

--- a/.tomty/tasks/code-chunks-eval/task.bash
+++ b/.tomty/tasks/code-chunks-eval/task.bash
@@ -1,0 +1,18 @@
+#!bash
+
+cat $root_dir/task.bash
+
+cat << 'HERE' > $cache_root_dir/code.md
+```{raku}
+my $answer = 42;
+```
+HERE
+
+raku examples/file-code-chunks-eval.raku  \
+--evalOutputPrompt="## OUTPUT :: " \
+--evalErrorPrompt="## ERROR :: " \
+-o=$cache_root_dir/out.md $cache_root_dir/code.md
+
+echo "==="
+
+cat $cache_root_dir/out.md

--- a/.tomty/tasks/code-chunks-eval/task.check
+++ b/.tomty/tasks/code-chunks-eval/task.check
@@ -1,0 +1,9 @@
+begin:
+===
+  ```{raku}
+  my $answer = 42;
+  ```
+  ```
+  regexp: ^^ \S+ \s+ 'OUTPUT :: 42'
+  ```
+end:


### PR DESCRIPTION
Hi! I believe Tomty could be quite handy to test Raku-Text-CodeProcessing , because it's uses Raku regexp to check stdout. If you like the idea I can add more tests.

Tests could be run like this:

```
tomty --all
```